### PR TITLE
Quickfix: styling grouped links for the left rail

### DIFF
--- a/style.css
+++ b/style.css
@@ -3359,6 +3359,9 @@ h4#formTrigger.colomat-close{
 	color:#fff;
 	cursor:pointer;
 }
+a.buttonLink.grouped{
+	margin-bottom:16px;
+}
 #secondary #formTrigger:hover,#secondary a.buttonLink:hover{
 	background-color:#c3a250 !important;
 	color:#fff !important;


### PR DESCRIPTION
Adding a style rule that will allow us to give links proper spacing so we can have one widget for a group of pages instead of having separate widgets for each individual link