### PR TITLE
Hide randomly empty fields on master tuition page

### DIFF
--- a/templates/tuition-page.php
+++ b/templates/tuition-page.php
@@ -36,6 +36,9 @@ get_header(); ?>
 	border-left:2px solid #115438;
 width:100px;
 }
+.featured_image_cropped,.sidebar_image_new{
+	display:none; /* hiding fields that shouldn't be here but Ryan can't track down */
+}
 </style>
   <div class="section-heading">
       <h1 class="field-title">


### PR DESCRIPTION
The way that we're getting the fields onto this page involves dumping all the ACF fields on the page. That means that we're getting fields that are everywhere that we don't care about (featured_image_cropped and sidebar_image_new) hiding these with CSS until the cause of their appearance can be tracked down