### PR TITLE
Removing build status comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-[![Build Status](https://travis-ci.org/Automattic/_s.svg?branch=master)](https://travis-ci.org/Automattic/_s)
-
-_s
-===
-
 Hi. I'm a starter theme called `_s`, or `underscores`, if you like. I'm a theme meant for hacking so don't use me as a Parent Theme. Instead try turning me into the next, most awesome, WordPress theme out there. That's what I'm here for.
 
 My ultra-minimal CSS might make me look like theme tartare but that means less stuff to get in your way when you're designing your awesome theme. Here are some of the other more interesting things you'll find here:


### PR DESCRIPTION
Removing build status comment because that was a tool that was used by the initial creators of this theme, not the people using and maintaining it.