### PR TITLE
Removing the left rail from the library interior page. Now that pages…

### DIFF
--- a/templates/library-interior-page.php
+++ b/templates/library-interior-page.php
@@ -26,7 +26,7 @@ get_header("library"); ?>
       </h1>
   </div>
 	<div id="primary" class="content-area pure-g">
-		<main id="main" class="site-main pure-u-1 <?php echo ($has_sidebar ? "pure-u-md-7-12 pure-u-lg-2-3" : "standalone") ; ?>" role="main">
+		<main id="main" class="site-main pure-u-1 standalone" role="main">
 
 			<?php
 			while ( have_posts() ) : the_post();
@@ -42,11 +42,8 @@ get_header("library"); ?>
 			?>
 
 		</main><!-- #main -->
-    <?php if ($has_sidebar) : ?>
-        <?php get_sidebar(); ?>
-    <?php endif; ?>
-    
-	</div><!-- #primary -->
+
+</div><!-- #primary -->
 
 <?php
 get_footer("library");


### PR DESCRIPTION
… are starting to be properly organized under the /library parentm having the left rail affects the layout in a negative way so it is being removed