### PR TITLE
Hotfix style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -4004,7 +4004,7 @@ th .smallText{
 	-ms-filter: grayscale();
 	filter: grayscale();
 }
-.grey-to-color:hover,.event2:hover img{
+.grey-to-color:hover,.event:hover img{
 	-webkit-filter: grayscale(0);
 	-moz-filter: grayscale(0);
 	-o-filter: grayscale(0);


### PR DESCRIPTION
When the classes were changed from event2 -> event for the news/events launch this style was missed because it is in a different section. Replacing that and pushing it live.