### PR TITLE
Replacing margin and padding on header

### DIFF
--- a/style.css
+++ b/style.css
@@ -4027,6 +4027,8 @@ th .smallText{
 	color:#004731;
 	font-weight:bold;
 	padding-left:25px;
+	margin-top:0;
+	padding-top:10px;
 }
 #courses .collapseomatic_content{
 	border:unset;


### PR DESCRIPTION
When the quick info box doesn't show up the margin-top causes weird spacing issues. Replacing that with padding-top to fix the issue