### PR TITLE
Update apply link in main-nav

### DIFF
--- a/template-parts/main-nav.php
+++ b/template-parts/main-nav.php
@@ -33,7 +33,7 @@
 			</ul>
 		</li>
 		<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9764">
-			<a id="interested-in-applying" href="https://www.elms.edu/interested-in-applying/">Apply</a>
+			<a id="interested-in-applying" href="https://elms.elluciancrmrecruit.com/Apply/Account/Login">Apply</a>
 			<a id="link-give" href="https://www.elms.edu/alumni/support-elms/make-a-gift/">Give</a>
 		</li>
 	</ul>


### PR DESCRIPTION
Now that the CRM-based CE application has gone live, we can change the apply link in the top left corner to point to the CRM login page instead of /interested-in-applying