### PR TITLE
Amending the open popup button to <hopefully> trigger the tracking of…

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -407,6 +407,7 @@
 		document.querySelector('.requestInfo-trigger').addEventListener('click', function () {
 			"use strict";
 			MicroModal.show('requestInfo');
+			fbq('trackCustom', 'RequestInfo');
 		});
 	}
 


### PR DESCRIPTION
… a custom event in FaceBook pixel. This should be tracked in both the MassLive and Way Better Marketing pixels