### PR TITLE
Update header-advertising.php

### DIFF
--- a/header-advertising.php
+++ b/header-advertising.php
@@ -18,9 +18,11 @@
 <link rel="profile" href="http://gmpg.org/xfn/11">
 
 <?php wp_head(); ?>
+<?php the_field("head_code", "option") ?>
 </head>
 
 <body id="advertising-landing-page">
+<?php the_field("body_code", "option") ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'gs_elms' ); ?></a>
   


### PR DESCRIPTION
When the template for the advertising landing pages was created, the code to put Google Tag Manager on the page was accidentally omitted. Adding the code to pull the ACF fields with the Tag Manager code into the header of these pages so it works like the main templates