### PR TITLE
Removing inline styles from /info

### DIFF
--- a/style.css
+++ b/style.css
@@ -3626,3 +3626,7 @@ a.text.requestInfo-trigger{
 }
 .focal-image-container{display:none;}
 /* END customizations from within the admin section */
+.page-id-38313 .social-media .social-media-inner{margin-top:0px;}
+.page-id-38313 #primary{background-image:url("https://www.elms.edu/wp-content/uploads/2018/06/berchmans-spring-18.jpg");max-height:775px;max-width:unset;background-repeat:no-repeat;background-size:cover;}
+.page-id-38313 :not(.mobile-or-library) .current-menu-ancestor{background-color:unset !important}
+.page-id-38313 :not(.mobile-or-library) .current-menu-ancestor:hover{background-color:#115438}


### PR DESCRIPTION
The /info URL has an inline style block that is breaking styles on the search page when that page appears in the results. Fixing this by removing the styles from the block and putting them in styles. css