### PR TITLE
Update functions.php to remove emojis

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -552,3 +552,31 @@ if($GLOBALS["blog_id"] == 1){
 	}
 	add_action( 'init', 'cptui_register_my_cpts_lp' );
 }
+
+/**
+ * Disable the emoji's
+ */
+function disable_emojis() {
+	remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+	remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+	remove_action( 'wp_print_styles', 'print_emoji_styles' );
+	remove_action( 'admin_print_styles', 'print_emoji_styles' );	
+	remove_filter( 'the_content_feed', 'wp_staticize_emoji' );
+	remove_filter( 'comment_text_rss', 'wp_staticize_emoji' );	
+	remove_filter( 'wp_mail', 'wp_staticize_emoji_for_email' );
+	
+	// Remove from TinyMCE
+	add_filter( 'tiny_mce_plugins', 'disable_emojis_tinymce' );
+}
+add_action( 'init', 'disable_emojis' );
+
+/**
+ * Filter out the tinymce emoji plugin.
+ */
+function disable_emojis_tinymce( $plugins ) {
+	if ( is_array( $plugins ) ) {
+		return array_diff( $plugins, array( 'wpemoji' ) );
+	} else {
+		return array();
+	}
+}


### PR DESCRIPTION
Removing WordPress' default emoji handling because it is not being used and it is slowing down the pages. Doing this via a script found here: https://gist.github.com/netmagik/88e004b17e4cc43d04b6